### PR TITLE
Vehicle testing

### DIFF
--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -71,6 +71,7 @@ class CfgVehicles {
 							statement = QUOTE([true] call FUNC(saveLRSettings));
 							condition = QUOTE(ALTERNATE_LAYOUT && SHOW_LR && HAS_LR);
 						};
+            
 						class Save_SR {
 							icon = QUOTE(ICON_PATH(sr));
 							displayName = "SR";
@@ -78,24 +79,32 @@ class CfgVehicles {
 							condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR && HAS_SR);
 						};
 					};
+          
 					//New Layout, ALTERNATE_LAYOUT = True
 					class Load_Root {
 						displayName = "Load";
 						icon = QUOTE(ICON_PATH(load));
 						statement = QUOTE(if(SHORTCUT_ENABLED && SHOW_LR && SHOW_SR) then {[true] call FUNC(loadBothSettings)};);
+<<<<<<< HEAD
 						condition = QUOTE(ALTERNATE_LAYOUT);
+=======
+            condition = QUOTE(ALTERNATE_LAYOUT);
+
+>>>>>>> vehicleTesting
 						class Load_LR {
 							displayName = "LR";
 							icon = QUOTE(ICON_PATH(lr));
 							statement = QUOTE([true] call FUNC(loadLRSettings));
 							condition = QUOTE(ALTERNATE_LAYOUT && (SHOW_LR) && HAS_LR);
 						};
+            
 						class Load_SR {
 							displayName = "SR";
 							icon = QUOTE(ICON_PATH(sr));
 							statement = QUOTE([true] call FUNC(loadSRSettings));
 							condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR && HAS_sR);
 						};
+            
 						class Load_Both {
 							displayName = "Both";
 							icon = QUOTE(ICON_PATH(interact_root));

--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -9,97 +9,99 @@ class CfgVehicles {
     class Man;
     class CAManBase: Man {
         class ACE_SelfActions {
-			class ADDON {
-				displayName = "TFAR Setter";
-				icon = QUOTE(ICON_PATH(interact_root));
-				exceptions[] = {
-					"isNotInside",
-					"isNotSwimming",
-					"isNotSitting",
-					"notOnMap"
-				};
-				class Load_Both {
-					displayName = "Load Both";
+			class ACE_Equipment {
+				class ADDON {
+					displayName = "TFAR Setter";
 					icon = QUOTE(ICON_PATH(interact_root));
-					statement = QUOTE([true] call FUNC(loadBothSettings));
-					condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && SHOW_SR);
-				};
-				//Original Layout, ALTERNATE_LAYOUT = False
-				class LR_Root {
-					displayName = "LR";
-					icon = QUOTE(ICON_PATH(lr));
-					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
-					condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR);
-					class LR_Load {
-						icon = QUOTE(ICON_PATH(load));
-						statement = QUOTE([true] call FUNC(loadLRSettings));
-						displayName = "Load";
-					};
-					class LR_Save {
-						icon = QUOTE(ICON_PATH(save));
-						statement = QUOTE([true] call FUNC(saveLRSettings));
-						displayName = "Save";
-					};
-				};
-				//Original Layout, ALTERNATE_LAYOUT = False
-				class SR_Root {
-					displayName = "SR";
-					icon = QUOTE(ICON_PATH(sr));
-					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadSRSettings)};);
-					condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_SR && HAS_SR);
-					class SR_Load {
-						icon = QUOTE(ICON_PATH(load));
-						statement = QUOTE([true] call FUNC(loadSRSettings));
-						displayName = "Load";
-					};
-					class SR_Save {
-						icon = QUOTE(ICON_PATH(save));
-						statement = QUOTE([true] call FUNC(saveSRSettings));
-						displayName = "Save";
-					};
-				};
-				//New Layout, ALTERNATE_LAYOUT = True
-				class Save_Root {
-					displayName = "Save";
-					statement = "";
-					condition = QUOTE(ALTERNATE_LAYOUT && (SHOW_LR || SHOW_SR) && (HAS_LR || HAS_SR));
-					icon = QUOTE(ICON_PATH(save));
-					class Save_LR {
-						displayName = "LR";
-						icon = QUOTE(ICON_PATH(lr));
-						statement = QUOTE([true] call FUNC(saveLRSettings));
-						condition = QUOTE(ALTERNATE_LAYOUT && SHOW_LR);
-					};
-					class Save_SR {
-						icon = QUOTE(ICON_PATH(sr));
-						displayName = "SR";
-						statement = QUOTE([true] call FUNC(saveSRSettings));
-						condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR);
-					};
-				};
-				//New Layout, ALTERNATE_LAYOUT = True
-				class Load_Root {
-					displayName = "Load";
-					icon = QUOTE(ICON_PATH(load));
-					statement = QUOTE(if(SHORTCUT_ENABLED && SHOW_LR && SHOW_SR) then {[true] call FUNC(loadBothSettings)};);
-					condition = QUOTE(ALTERNATE_LAYOUT);
-					class Load_LR {
-						displayName = "LR";
-						icon = QUOTE(ICON_PATH(lr));
-						statement = QUOTE([true] call FUNC(loadLRSettings));
-						condition = QUOTE(ALTERNATE_LAYOUT && (SHOW_LR));
-					};
-					class Load_SR {
-						displayName = "SR";
-						icon = QUOTE(ICON_PATH(sr));
-						statement = QUOTE([true] call FUNC(loadSRSettings));
-						condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR);
+					exceptions[] = {
+						"isNotInside",
+						"isNotSwimming",
+						"isNotSitting",
+						"notOnMap"
 					};
 					class Load_Both {
-						displayName = "Both";
+						displayName = "Load Both";
 						icon = QUOTE(ICON_PATH(interact_root));
 						statement = QUOTE([true] call FUNC(loadBothSettings));
-						condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR && SHOW_LR);
+						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && SHOW_SR && HAS_LR && HAS_SR);
+					};
+					//Original Layout, ALTERNATE_LAYOUT = False
+					class LR_Root {
+						displayName = "LR";
+						icon = QUOTE(ICON_PATH(lr));
+						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
+						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && HAS_LR);
+						class LR_Load {
+							icon = QUOTE(ICON_PATH(load));
+							statement = QUOTE([true] call FUNC(loadLRSettings));
+							displayName = "Load";
+						};
+						class LR_Save {
+							icon = QUOTE(ICON_PATH(save));
+							statement = QUOTE([true] call FUNC(saveLRSettings));
+							displayName = "Save";
+						};
+					};
+					//Original Layout, ALTERNATE_LAYOUT = False
+					class SR_Root {
+						displayName = "SR";
+						icon = QUOTE(ICON_PATH(sr));
+						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadSRSettings)};);
+						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_SR && HAS_SR);
+						class SR_Load {
+							icon = QUOTE(ICON_PATH(load));
+							statement = QUOTE([true] call FUNC(loadSRSettings));
+							displayName = "Load";
+						};
+						class SR_Save {
+							icon = QUOTE(ICON_PATH(save));
+							statement = QUOTE([true] call FUNC(saveSRSettings));
+							displayName = "Save";
+						};
+					};
+					//New Layout, ALTERNATE_LAYOUT = True
+					class Save_Root {
+						displayName = "Save";
+						statement = "";
+						condition = QUOTE(ALTERNATE_LAYOUT && (SHOW_LR || SHOW_SR) && (HAS_LR || HAS_SR));
+						icon = QUOTE(ICON_PATH(save));
+						class Save_LR {
+							displayName = "LR";
+							icon = QUOTE(ICON_PATH(lr));
+							statement = QUOTE([true] call FUNC(saveLRSettings));
+							condition = QUOTE(ALTERNATE_LAYOUT && SHOW_LR && HAS_LR);
+						};
+						class Save_SR {
+							icon = QUOTE(ICON_PATH(sr));
+							displayName = "SR";
+							statement = QUOTE([true] call FUNC(saveSRSettings));
+							condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR && HAS_SR);
+						};
+					};
+					//New Layout, ALTERNATE_LAYOUT = True
+					class Load_Root {
+						displayName = "Load";
+						icon = QUOTE(ICON_PATH(load));
+						statement = QUOTE(if(SHORTCUT_ENABLED && SHOW_LR && SHOW_SR) then {[true] call FUNC(loadBothSettings)};);
+						condition = QUOTE(ALTERNATE_LAYOUT);
+						class Load_LR {
+							displayName = "LR";
+							icon = QUOTE(ICON_PATH(lr));
+							statement = QUOTE([true] call FUNC(loadLRSettings));
+							condition = QUOTE(ALTERNATE_LAYOUT && (SHOW_LR) && HAS_LR);
+						};
+						class Load_SR {
+							displayName = "SR";
+							icon = QUOTE(ICON_PATH(sr));
+							statement = QUOTE([true] call FUNC(loadSRSettings));
+							condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR && HAS_sR);
+						};
+						class Load_Both {
+							displayName = "Both";
+							icon = QUOTE(ICON_PATH(interact_root));
+							statement = QUOTE([true] call FUNC(loadBothSettings));
+							condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR && SHOW_LR && HAS_LR && HAS_SR);
+						};
 					};
 				};
 			};
@@ -108,24 +110,26 @@ class CfgVehicles {
     class Air;
     class Helicopter: Air {
         class ACE_SelfActions {
-			class ADDON {	
-				displayName = "TFAR Setter";
-				icon = QUOTE(ICON_PATH(interact_root));
-				//Original Layout, ALTERNATE_LAYOUT = False
-				class LR_Root {
-					displayName = "Vehicle LR";
-					icon = QUOTE(ICON_PATH(lr));
-					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
-					condition = QUOTE(SHOW_LR);
-					class LR_Load {
-						icon = QUOTE(ICON_PATH(load));
-						statement = QUOTE([true] call FUNC(loadVLRSettings));
-						displayName = "Load";
-					};
-					class LR_Save {
-						icon = QUOTE(ICON_PATH(save));
-						statement = QUOTE([true] call FUNC(saveVLRSettings));
-						displayName = "Save";
+			ACE_Equipment{
+				class ADDON {	
+					displayName = "TFAR Setter";
+					icon = QUOTE(ICON_PATH(interact_root));
+					//Original Layout, ALTERNATE_LAYOUT = False
+					class LR_Root {
+						displayName = "Vehicle LR";
+						icon = QUOTE(ICON_PATH(lr));
+						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
+						condition = QUOTE(SHOW_LR && && HAS_LR);
+						class LR_Load {
+							icon = QUOTE(ICON_PATH(load));
+							statement = QUOTE([true] call FUNC(loadVLRSettings));
+							displayName = "Load";
+						};
+						class LR_Save {
+							icon = QUOTE(ICON_PATH(save));
+							statement = QUOTE([true] call FUNC(saveVLRSettings));
+							displayName = "Save";
+						};
 					};
 				};
 			};

--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -110,26 +110,24 @@ class CfgVehicles {
     class Air;
     class Helicopter: Air {
         class ACE_SelfActions {
-			ACE_Equipment{
-				class ADDON {	
-					displayName = "TFAR Setter";
-					icon = QUOTE(ICON_PATH(interact_root));
-					//Original Layout, ALTERNATE_LAYOUT = False
-					class LR_Root {
-						displayName = "Vehicle LR";
-						icon = QUOTE(ICON_PATH(lr));
-						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
-						condition = QUOTE(SHOW_LR && && HAS_LR);
-						class LR_Load {
-							icon = QUOTE(ICON_PATH(load));
-							statement = QUOTE([true] call FUNC(loadVLRSettings));
-							displayName = "Load";
-						};
-						class LR_Save {
-							icon = QUOTE(ICON_PATH(save));
-							statement = QUOTE([true] call FUNC(saveVLRSettings));
-							displayName = "Save";
-						};
+			class ADDON {	
+				displayName = "TFAR Setter";
+				icon = QUOTE(ICON_PATH(interact_root));
+				//Original Layout, ALTERNATE_LAYOUT = False
+				class LR_Root {
+					displayName = "Vehicle LR";
+					icon = QUOTE(ICON_PATH(lr));
+					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
+					condition = QUOTE(SHOW_LR && && HAS_LR);
+					class LR_Load {
+						icon = QUOTE(ICON_PATH(load));
+						statement = QUOTE([true] call FUNC(loadVLRSettings));
+						displayName = "Load";
+					};
+					class LR_Save {
+						icon = QUOTE(ICON_PATH(save));
+						statement = QUOTE([true] call FUNC(saveVLRSettings));
+						displayName = "Save";
 					};
 				};
 			};

--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -85,12 +85,8 @@ class CfgVehicles {
 						displayName = "Load";
 						icon = QUOTE(ICON_PATH(load));
 						statement = QUOTE(if(SHORTCUT_ENABLED && SHOW_LR && SHOW_SR) then {[true] call FUNC(loadBothSettings)};);
-<<<<<<< HEAD
-						condition = QUOTE(ALTERNATE_LAYOUT);
-=======
-            condition = QUOTE(ALTERNATE_LAYOUT);
+           				condition = QUOTE(ALTERNATE_LAYOUT && (HAS_LR || HAS_SR));
 
->>>>>>> vehicleTesting
 						class Load_LR {
 							displayName = "LR";
 							icon = QUOTE(ICON_PATH(lr));
@@ -117,6 +113,8 @@ class CfgVehicles {
 		};
     };
     class Air;
+	class Plane: Air;
+	
     class Helicopter: Air {
         class ACE_SelfActions {
 			class ADDON {	
@@ -142,4 +140,32 @@ class CfgVehicles {
 			};
 		};
 	};
+	
+	class Plane_Base_F: Plane{
+		class ACE_SelfActions {
+			class ADDON {	
+				displayName = "TFAR Setter";
+				icon = QUOTE(ICON_PATH(interact_root));
+				//Original Layout, ALTERNATE_LAYOUT = False
+				class LR_Root {
+					displayName = "Vehicle LR";
+					icon = QUOTE(ICON_PATH(lr));
+					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
+					condition = QUOTE(SHOW_LR && && HAS_LR);
+					class LR_Load {
+						icon = QUOTE(ICON_PATH(load));
+						statement = QUOTE([true] call FUNC(loadVLRSettings));
+						displayName = "Load";
+					};
+					class LR_Save {
+						icon = QUOTE(ICON_PATH(save));
+						statement = QUOTE([true] call FUNC(saveVLRSettings));
+						displayName = "Save";
+					};
+				};
+			};
+		};
+	};
+		
+
 };

--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -125,7 +125,7 @@ class CfgVehicles {
 					displayName = "Vehicle LR";
 					icon = QUOTE(ICON_PATH(lr));
 					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
-					condition = QUOTE(SHOW_LR && && HAS_LR);
+					condition = QUOTE(SHOW_LR && HAS_LR);
 					class LR_Load {
 						icon = QUOTE(ICON_PATH(load));
 						statement = QUOTE([true] call FUNC(loadVLRSettings));
@@ -151,7 +151,7 @@ class CfgVehicles {
 					displayName = "Vehicle LR";
 					icon = QUOTE(ICON_PATH(lr));
 					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
-					condition = QUOTE(SHOW_LR && && HAS_LR);
+					condition = QUOTE(SHOW_LR && HAS_LR);
 					class LR_Load {
 						icon = QUOTE(ICON_PATH(load));
 						statement = QUOTE([true] call FUNC(loadVLRSettings));

--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -9,102 +9,126 @@ class CfgVehicles {
     class Man;
     class CAManBase: Man {
         class ACE_SelfActions {
-			class ACE_Equipment {
-				class ADDON {
-					displayName = "TFAR Setter";
+			class ADDON {
+				displayName = "TFAR Setter";
+				icon = QUOTE(ICON_PATH(interact_root));
+				exceptions[] = {
+					"isNotInside",
+					"isNotSwimming",
+					"isNotSitting",
+					"notOnMap"
+				};
+				class Load_Both {
+					displayName = "Load Both";
 					icon = QUOTE(ICON_PATH(interact_root));
-					exceptions[] = {
-						"isNotInside",
-						"isNotSwimming",
-						"isNotSitting",
-						"notOnMap"
+					statement = QUOTE([true] call FUNC(loadBothSettings));
+					condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && SHOW_SR);
+				};
+				//Original Layout, ALTERNATE_LAYOUT = False
+				class LR_Root {
+					displayName = "LR";
+					icon = QUOTE(ICON_PATH(lr));
+					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
+					condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR);
+					class LR_Load {
+						icon = QUOTE(ICON_PATH(load));
+						statement = QUOTE([true] call FUNC(loadLRSettings));
+						displayName = "Load";
 					};
-					class Load_Both {
-						displayName = "Load Both";
-						icon = QUOTE(ICON_PATH(interact_root));
-						statement = QUOTE([true] call FUNC(loadBothSettings));
-						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && SHOW_SR && HAS_LR && HAS_SR);
+					class LR_Save {
+						icon = QUOTE(ICON_PATH(save));
+						statement = QUOTE([true] call FUNC(saveLRSettings));
+						displayName = "Save";
 					};
-					//Original Layout, ALTERNATE_LAYOUT = False
-					class LR_Root {
+				};
+				//Original Layout, ALTERNATE_LAYOUT = False
+				class SR_Root {
+					displayName = "SR";
+					icon = QUOTE(ICON_PATH(sr));
+					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadSRSettings)};);
+					condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_SR && HAS_SR);
+					class SR_Load {
+						icon = QUOTE(ICON_PATH(load));
+						statement = QUOTE([true] call FUNC(loadSRSettings));
+						displayName = "Load";
+					};
+					class SR_Save {
+						icon = QUOTE(ICON_PATH(save));
+						statement = QUOTE([true] call FUNC(saveSRSettings));
+						displayName = "Save";
+					};
+				};
+				//New Layout, ALTERNATE_LAYOUT = True
+				class Save_Root {
+					displayName = "Save";
+					statement = "";
+					condition = QUOTE(ALTERNATE_LAYOUT && (SHOW_LR || SHOW_SR) && (HAS_LR || HAS_SR));
+					icon = QUOTE(ICON_PATH(save));
+					class Save_LR {
 						displayName = "LR";
 						icon = QUOTE(ICON_PATH(lr));
-						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
-						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && HAS_LR);
-						class LR_Load {
-							icon = QUOTE(ICON_PATH(load));
-							statement = QUOTE([true] call FUNC(loadLRSettings));
-							displayName = "Load";
-						};
-						class LR_Save {
-							icon = QUOTE(ICON_PATH(save));
-							statement = QUOTE([true] call FUNC(saveLRSettings));
-							displayName = "Save";
-						};
+						statement = QUOTE([true] call FUNC(saveLRSettings));
+						condition = QUOTE(ALTERNATE_LAYOUT && SHOW_LR);
 					};
-					//Original Layout, ALTERNATE_LAYOUT = False
-					class SR_Root {
+					class Save_SR {
+						icon = QUOTE(ICON_PATH(sr));
+						displayName = "SR";
+						statement = QUOTE([true] call FUNC(saveSRSettings));
+						condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR);
+					};
+				};
+				//New Layout, ALTERNATE_LAYOUT = True
+				class Load_Root {
+					displayName = "Load";
+					icon = QUOTE(ICON_PATH(load));
+					statement = QUOTE(if(SHORTCUT_ENABLED && SHOW_LR && SHOW_SR) then {[true] call FUNC(loadBothSettings)};);
+					condition = QUOTE(ALTERNATE_LAYOUT);
+					class Load_LR {
+						displayName = "LR";
+						icon = QUOTE(ICON_PATH(lr));
+						statement = QUOTE([true] call FUNC(loadLRSettings));
+						condition = QUOTE(ALTERNATE_LAYOUT && (SHOW_LR));
+					};
+					class Load_SR {
 						displayName = "SR";
 						icon = QUOTE(ICON_PATH(sr));
-						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadSRSettings)};);
-						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_SR && HAS_SR);
-						class SR_Load {
-							icon = QUOTE(ICON_PATH(load));
-							statement = QUOTE([true] call FUNC(loadSRSettings));
-							displayName = "Load";
-						};
-						class SR_Save {
-							icon = QUOTE(ICON_PATH(save));
-							statement = QUOTE([true] call FUNC(saveSRSettings));
-							displayName = "Save";
-						};
+						statement = QUOTE([true] call FUNC(loadSRSettings));
+						condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR);
 					};
-					//New Layout, ALTERNATE_LAYOUT = True
-					class Save_Root {
-						displayName = "Save";
-						statement = "";
-						condition = QUOTE(ALTERNATE_LAYOUT && (SHOW_LR || SHOW_SR) && (HAS_LR || HAS_SR));
-						icon = QUOTE(ICON_PATH(save));
-						class Save_LR {
-							displayName = "LR";
-							icon = QUOTE(ICON_PATH(lr));
-							statement = QUOTE([true] call FUNC(saveLRSettings));
-							condition = QUOTE(SHOW_LR && HAS_LR);
-						};
-						class Save_SR {
-							icon = QUOTE(ICON_PATH(sr));
-							displayName = "SR";
-							statement = QUOTE([true] call FUNC(saveSRSettings));
-							condition = QUOTE(SHOW_SR && HAS_SR);
-						};
-					};
-					//New Layout, ALTERNATE_LAYOUT = True
-					class Load_Root {
-						displayName = "Load";
-						icon = QUOTE(ICON_PATH(load));
-						statement = QUOTE(if(SHORTCUT_ENABLED && SHOW_LR && SHOW_SR) then {[true] call FUNC(loadBothSettings)};);
-						condition = QUOTE(ALTERNATE_LAYOUT && (HAS_LR || HAS_SR));
-						class Load_LR {
-							displayName = "LR";
-							icon = QUOTE(ICON_PATH(lr));
-							statement = QUOTE([true] call FUNC(loadLRSettings));
-							condition = QUOTE(SHOW_LR && HAS_LR);
-						};
-						class Load_SR {
-							displayName = "SR";
-							icon = QUOTE(ICON_PATH(sr));
-							statement = QUOTE([true] call FUNC(loadSRSettings));
-							condition = QUOTE(SHOW_SR && HAS_SR);
-						};
-						class Load_Both {
-							displayName = "Both";
-							icon = QUOTE(ICON_PATH(interact_root));
-							statement = QUOTE([true] call FUNC(loadBothSettings));
-							condition = QUOTE(SHOW_LR && SHOW_SR && HAS_LR && HAS_SR);
-						};
+					class Load_Both {
+						displayName = "Both";
+						icon = QUOTE(ICON_PATH(interact_root));
+						statement = QUOTE([true] call FUNC(loadBothSettings));
+						condition = QUOTE(ALTERNATE_LAYOUT && SHOW_SR && SHOW_LR);
 					};
 				};
 			};
 		};
     };
+    class Air;
+    class Helicopter: Air {
+        class ACE_SelfActions {
+			class ADDON {	
+				displayName = "TFAR Setter";
+				icon = QUOTE(ICON_PATH(interact_root));
+				//Original Layout, ALTERNATE_LAYOUT = False
+				class LR_Root {
+					displayName = "Vehicle LR";
+					icon = QUOTE(ICON_PATH(lr));
+					statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
+					condition = QUOTE(SHOW_LR);
+					class LR_Load {
+						icon = QUOTE(ICON_PATH(load));
+						statement = QUOTE([true] call FUNC(loadVLRSettings));
+						displayName = "Load";
+					};
+					class LR_Save {
+						icon = QUOTE(ICON_PATH(save));
+						statement = QUOTE([true] call FUNC(saveVLRSettings));
+						displayName = "Save";
+					};
+				};
+			};
+		};
+	};
 };

--- a/CHTR_TFAR_Setter/config.cpp
+++ b/CHTR_TFAR_Setter/config.cpp
@@ -19,6 +19,8 @@ class CfgFunctions {
             file = FUNCTION_PATH;
 			class loadLRSettings {};
 			class saveLRSettings {};
+			class loadVLRSettings {};
+			class saveVLRSettings {};
 			class loadSRSettings {};
 			class saveSRSettings {};
 			class showLRCheck {};

--- a/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
@@ -4,10 +4,6 @@
  *
  * Arguments:
  * 0: LR, SR, or vehicleLR (2, 3, 5) (default:2) <INTEGER>
-<<<<<<< HEAD
-=======
-
->>>>>>> vehicleTesting
  *
  * Return Value:
  * TFAR Radio Data <ARRAY>
@@ -20,10 +16,6 @@
 #include "function_macros.hpp"
 params[
 	["_radio", 2, [1.0]]
-<<<<<<< HEAD
-=======
-
->>>>>>> vehicleTesting
 ];
 
 _settings = call FUNC(loadSettings);
@@ -34,12 +26,12 @@ if(count _settings == 0) exitWith {
 _profileIndex = (_settings select 0) + 1;
 _currentProfile = _settings select _profileIndex;
 
-/*if(_radio = 3) then {
+if(_radio = 3) then {
 	LOG("Fetching SR Radio Data");
-}else if(_radio = 2) then {
-	LOG("Fetching LR Radio Data");
-}else
-{
-	LOG("Fetching Vehicle LR Radio Data");
-};*/
-_currentProfile select _radio;
+	}else if(_radio = 2) then {
+		LOG("Fetching LR Radio Data");
+	}else{
+		LOG("Fetching Vehicle LR Radio Data");
+};
+
+_currentProfile select _index;

--- a/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
@@ -26,12 +26,12 @@ if(count _settings == 0) exitWith {
 _profileIndex = (_settings select 0) + 1;
 _currentProfile = _settings select _profileIndex;
 
-if(_radio = 3) then {
+/*if(_radio = 3) then {
 	LOG("Fetching SR Radio Data");
-	}else if(_radio = 2) then {
-		LOG("Fetching LR Radio Data");
-	}else{
-		LOG("Fetching Vehicle LR Radio Data");
-};
+}else if(_radio = 2) then {
+	LOG("Fetching LR Radio Data");
+}else{
+	LOG("Fetching Vehicle LR Radio Data");
+};*/
 
 _currentProfile select _index;

--- a/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
@@ -3,7 +3,7 @@
  * Gets either LR or SR radio data from the settings array and returns it
  *
  * Arguments:
- * 0: LR if true, SR if False <BOOLEAN>
+ * 0: LR, SR, or vehicleLR (2, 3, 5) (default:2) <INTEGER>
  *
  * Return Value:
  * TFAR Radio Data <ARRAY>

--- a/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
@@ -4,6 +4,10 @@
  *
  * Arguments:
  * 0: LR, SR, or vehicleLR (2, 3, 5) (default:2) <INTEGER>
+<<<<<<< HEAD
+=======
+
+>>>>>>> vehicleTesting
  *
  * Return Value:
  * TFAR Radio Data <ARRAY>
@@ -16,6 +20,10 @@
 #include "function_macros.hpp"
 params[
 	["_radio", 2, [1.0]]
+<<<<<<< HEAD
+=======
+
+>>>>>>> vehicleTesting
 ];
 
 _settings = call FUNC(loadSettings);

--- a/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
@@ -15,7 +15,7 @@
  */
 #include "function_macros.hpp"
 params[
-	["_lr", true, [true]]
+	["_radio", 2, [1.0]]
 ];
 
 _settings = call FUNC(loadSettings);
@@ -26,9 +26,12 @@ if(count _settings == 0) exitWith {
 _profileIndex = (_settings select 0) + 1;
 _currentProfile = _settings select _profileIndex;
 
-_index = 2;
-if(!_lr) then {
-	_index = 3;
-};
-
-_currentProfile select _index
+/*if(_radio = 3) then {
+	LOG("Fetching SR Radio Data");
+}else if(_radio = 2) then {
+	LOG("Fetching LR Radio Data");
+}else
+{
+	LOG("Fetching Vehicle LR Radio Data");
+};*/
+_currentProfile select _radio;

--- a/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
@@ -22,6 +22,10 @@ params[["_showResult", true, [true]]];
 
 LOG("Loading LR Settings");
 _radioData = [2] call FUNC(getRadioData);
+<<<<<<< HEAD
+=======
+
+>>>>>>> vehicleTesting
 if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset LR settings");
 	1

--- a/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
@@ -21,7 +21,7 @@
 params[["_showResult", true, [true]]];
 
 LOG("Loading LR Settings");
-_radioData = [3] call FUNC(getRadioData);
+_radioData = [2] call FUNC(getRadioData);
 if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset LR settings");
 	1

--- a/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
@@ -22,10 +22,6 @@ params[["_showResult", true, [true]]];
 
 LOG("Loading LR Settings");
 _radioData = [2] call FUNC(getRadioData);
-<<<<<<< HEAD
-=======
-
->>>>>>> vehicleTesting
 if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset LR settings");
 	1

--- a/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
@@ -22,6 +22,10 @@ params[["_showResult", true, [true]]];
 
 LOG("Loading SR Settings");
 _radioData = [3] call FUNC(getRadioData);
+<<<<<<< HEAD
+=======
+
+>>>>>>> vehicleTesting
 if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset SR settings");
 	1

--- a/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
@@ -22,10 +22,7 @@ params[["_showResult", true, [true]]];
 
 LOG("Loading SR Settings");
 _radioData = [3] call FUNC(getRadioData);
-<<<<<<< HEAD
-=======
 
->>>>>>> vehicleTesting
 if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset SR settings");
 	1

--- a/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
@@ -21,7 +21,7 @@
 params[["_showResult", true, [true]]];
 
 LOG("Loading SR Settings");
-_radioData = [false] call FUNC(getRadioData);
+_radioData = [3] call FUNC(getRadioData);
 if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset SR settings");
 	1

--- a/CHTR_TFAR_Setter/functions/fn_loadVLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadVLRSettings.sqf
@@ -12,7 +12,7 @@
  * None
  *
  * Example:
- * [true] call CHTR_TFAR_Setter_fnc_loadLRSettings
+ * [true] call CHTR_TFAR_Setter_fnc_loadVLRSettings
  *
  * Public: No
  */
@@ -22,6 +22,7 @@ params[["_showResult", true, [true]]];
 
 LOG("Loading LR Settings");
 _radioData = [5] call FUNC(getRadioData);
+
 if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset LR settings");
 	1

--- a/CHTR_TFAR_Setter/functions/fn_loadVLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadVLRSettings.sqf
@@ -21,14 +21,14 @@
 params[["_showResult", true, [true]]];
 
 LOG("Loading LR Settings");
-_radioData = [3] call FUNC(getRadioData);
+_radioData = [5] call FUNC(getRadioData);
 if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset LR settings");
 	1
 };
 [(call TFAR_fnc_activeLrRadio) select 0, (call TFAR_fnc_activeLrRadio) select 1, _radioData] call TFAR_fnc_setLrSettings;
-LOG(format["Loading LR Settings: %1", _radioData]);
+LOG(format["Loading Vehicle LR Settings: %1", _radioData]);
 if(_showResult) then {
-	["Loaded LR Settings", QUOTE(ICON_PATH(load))] call ace_common_fnc_displayTextPicture;
+	["Loaded Vehicle LR Settings", QUOTE(ICON_PATH(load))] call ace_common_fnc_displayTextPicture;
 };
 0

--- a/CHTR_TFAR_Setter/functions/fn_loadVLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadVLRSettings.sqf
@@ -1,6 +1,6 @@
 /*
  * Authors: Chatter and M3ales
- * calls getRadioData with true to _radioData to get Long Range data if any and checks to make sure it is not empty
+ * calls getRadioData with true to _radioData to get Vehicle Long Range data if any and checks to make sure it is not empty
  * Loads _radioData to currently equipped SR.
  * Outputs "Loaded SR Settings" in a hint as an indication of what was done.
  * 

--- a/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
@@ -23,6 +23,10 @@ params[["_showResult", true, [true]]];
 LOG("Saving LR Settings");
 _radioData = (call TFAR_fnc_activeLrRadio) call TFAR_fnc_getLrSettings;
 [2, _radioData] call FUNC(setRadioData);
+<<<<<<< HEAD
+=======
+
+>>>>>>> vehicleTesting
 
 if(_showResult) then {
 	["Saved LR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;

--- a/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
@@ -23,10 +23,6 @@ params[["_showResult", true, [true]]];
 LOG("Saving LR Settings");
 _radioData = (call TFAR_fnc_activeLrRadio) call TFAR_fnc_getLrSettings;
 [2, _radioData] call FUNC(setRadioData);
-<<<<<<< HEAD
-=======
-
->>>>>>> vehicleTesting
 
 if(_showResult) then {
 	["Saved LR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;

--- a/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
@@ -22,7 +22,7 @@ params[["_showResult", true, [true]]];
 
 LOG("Saving LR Settings");
 _radioData = (call TFAR_fnc_activeLrRadio) call TFAR_fnc_getLrSettings;
-[true, _radioData] call FUNC(setRadioData);
+[2, _radioData] call FUNC(setRadioData);
 
 if(_showResult) then {
 	["Saved LR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;

--- a/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
@@ -23,10 +23,6 @@ params[["_showResult", true, [true]]];
 LOG("Saving SR Settings");
 _radioData = (call TFAR_fnc_activeSwRadio) call TFAR_fnc_getSwSettings;
 [3, _radioData] call FUNC(setRadioData);
-<<<<<<< HEAD
-=======
-
->>>>>>> vehicleTesting
 
 if(_showResult) then {
 	["Saved SR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;

--- a/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
@@ -23,6 +23,10 @@ params[["_showResult", true, [true]]];
 LOG("Saving SR Settings");
 _radioData = (call TFAR_fnc_activeSwRadio) call TFAR_fnc_getSwSettings;
 [3, _radioData] call FUNC(setRadioData);
+<<<<<<< HEAD
+=======
+
+>>>>>>> vehicleTesting
 
 if(_showResult) then {
 	["Saved SR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;

--- a/CHTR_TFAR_Setter/functions/fn_saveVLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveVLRSettings.sqf
@@ -1,8 +1,8 @@
 /*
  * Authors: Chatter and M3ales
- * Saves current Long Range radio data to _radioData,
- * Pushes _radio data to setRadioData with TRUE to save Long Trange
- * Outputs "Saved SR Settings" in a hint as an indication of what was done.
+ * Saves current Active Vehicle Long Range radio data to _radioData,
+ * Pushes _radio data to setRadioData with 5 to save Vehicle Long Range
+ * Outputs "Saved Vehicle LR Settings" in a hint as an indication of what was done.
  * 
  *
  * Arguments:

--- a/CHTR_TFAR_Setter/functions/fn_saveVLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveVLRSettings.sqf
@@ -1,7 +1,7 @@
 /*
  * Authors: Chatter and M3ales
- * Saves current Short Range radio data to _radioData,
- * Pushes _radioData to setRadioData with FALSE to save Short Range data.
+ * Saves current Long Range radio data to _radioData,
+ * Pushes _radio data to setRadioData with TRUE to save Long Trange
  * Outputs "Saved SR Settings" in a hint as an indication of what was done.
  * 
  *
@@ -12,7 +12,7 @@
  * None
  *
  * Example:
- * call CHTR_TFAR_Setter_fnc_saveLRSettings
+ * [true] call CHTR_TFAR_Setter_fnc_saveLRSettings
  *
  * Public: No
  */
@@ -20,12 +20,12 @@
 
 params[["_showResult", true, [true]]];
 
-LOG("Saving SR Settings");
-_radioData = (call TFAR_fnc_activeSwRadio) call TFAR_fnc_getSwSettings;
-[3, _radioData] call FUNC(setRadioData);
+LOG("Saving Vehicle LR Settings");
+_radioData = (call TFAR_fnc_activeLrRadio) call TFAR_fnc_getLrSettings;
+[5, _radioData] call FUNC(setRadioData);
 
 if(_showResult) then {
-	["Saved SR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;
+	["Saved Vehicle LR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;
 };
 //check it saved correctly, return result
 0

--- a/CHTR_TFAR_Setter/functions/fn_saveVLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveVLRSettings.sqf
@@ -12,7 +12,7 @@
  * None
  *
  * Example:
- * [true] call CHTR_TFAR_Setter_fnc_saveLRSettings
+ * [true] call CHTR_TFAR_Setter_fnc_saveVLRSettings
  *
  * Public: No
  */

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -3,7 +3,7 @@
  * Sets LR/SR data of current profile
  *
  * Arguments:
- * 0: LR or SR, LR is true (default:true) <BOOLEAN>
+ * 0: LR or SR, LR is true (default:2) <INTEGER>
  * 1: Data to be saved (default: []) <ARRAY>
  * Return Value:
  * None
@@ -16,18 +16,17 @@
 #include "function_macros.hpp"
 
 params[
-	["_lr", true, [true]],
+	["_radio", 2, [1.0]],
 	["_value", [], [[]]]
 ];
 
-_index = 2;
-if(!_lr) then {
-	LOG("Saving SR Radio Data");
-	_index = 3;
-}else
-{
-	LOG("Saving LR Radio Data");
-};
+/*if(_radio = 3) then {
+	LOG("Pushing SR Radio Data");
+}else if(_radio = 2 ){
+	LOG("Pushing LR Radio Data");
+}else{
+	LOG("Pushing Vehicle LR Radio Data");
+};*/
 
 _settings = call FUNC(loadSettings);
 if(count _settings == 0) exitWith {
@@ -35,4 +34,4 @@ if(count _settings == 0) exitWith {
 };
 _profileIndex = (_settings select 0) + 1;
 _currentProfile = _settings select _profileIndex;
-_currentProfile set [_index, _value];
+_currentProfile set [_radio, _value];

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -4,6 +4,10 @@
  *
  * Arguments:
  * 0: LR, SR, or vehicleLR (2, 3, 5) (default:2) <INTEGER>
+<<<<<<< HEAD
+=======
+
+>>>>>>> vehicleTesting
  * 1: Data to be saved (default: []) <ARRAY>
  * Return Value:
  * None
@@ -27,6 +31,10 @@ params[
 }else{
 	LOG("Pushing Vehicle LR Radio Data");
 };*/
+<<<<<<< HEAD
+=======
+
+>>>>>>> vehicleTesting
 
 _settings = call FUNC(loadSettings);
 if(count _settings == 0) exitWith {
@@ -34,4 +42,8 @@ if(count _settings == 0) exitWith {
 };
 _profileIndex = (_settings select 0) + 1;
 _currentProfile = _settings select _profileIndex;
+<<<<<<< HEAD
 _currentProfile set [_radio, _value];
+=======
+_currentProfile set [_radio, _value];
+>>>>>>> vehicleTesting

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -3,7 +3,7 @@
  * Sets LR/SR data of current profile
  *
  * Arguments:
- * 0: LR or SR, LR is true (default:2) <INTEGER>
+ * 0: LR, SR, or vehicleLR (2, 3, 5) (default:2) <INTEGER>
  * 1: Data to be saved (default: []) <ARRAY>
  * Return Value:
  * None

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -4,10 +4,6 @@
  *
  * Arguments:
  * 0: LR, SR, or vehicleLR (2, 3, 5) (default:2) <INTEGER>
-<<<<<<< HEAD
-=======
-
->>>>>>> vehicleTesting
  * 1: Data to be saved (default: []) <ARRAY>
  * Return Value:
  * None
@@ -24,17 +20,13 @@ params[
 	["_value", [], [[]]]
 ];
 
-/*if(_radio = 3) then {
+if(_radio = 3) then {
 	LOG("Pushing SR Radio Data");
-}else if(_radio = 2 ){
+}else if(_radio = 2 ) then {
 	LOG("Pushing LR Radio Data");
 }else{
 	LOG("Pushing Vehicle LR Radio Data");
-};*/
-<<<<<<< HEAD
-=======
-
->>>>>>> vehicleTesting
+};
 
 _settings = call FUNC(loadSettings);
 if(count _settings == 0) exitWith {
@@ -42,8 +34,4 @@ if(count _settings == 0) exitWith {
 };
 _profileIndex = (_settings select 0) + 1;
 _currentProfile = _settings select _profileIndex;
-<<<<<<< HEAD
 _currentProfile set [_radio, _value];
-=======
-_currentProfile set [_radio, _value];
->>>>>>> vehicleTesting

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -20,13 +20,13 @@ params[
 	["_value", [], [[]]]
 ];
 
-if(_radio = 3) then {
+/*if(_radio = 3) then {
 	LOG("Pushing SR Radio Data");
 }else if(_radio = 2 ) then {
 	LOG("Pushing LR Radio Data");
 }else{
 	LOG("Pushing Vehicle LR Radio Data");
-};
+};*/
 
 _settings = call FUNC(loadSettings);
 if(count _settings == 0) exitWith {


### PR DESCRIPTION
-  Added Load and Save for Vehicles.
-  Vehicle interaction options have their own separate settings
-  Settings are applied to the currently active radio
### If you have a backpack LR on, you should set vehicle radio to active or it will use the settings from your backpack to save from, and will save to it. 
#### This should be fixed in the future once I'm able to reliably implement a way to set vehicleLR to the active through the script.
